### PR TITLE
Faker 1.6 is Released - Fix link

### DIFF
--- a/_posts/2016-04-29-faker-1-6.md
+++ b/_posts/2016-04-29-faker-1-6.md
@@ -9,7 +9,7 @@ tags:
 - php
 ---
 
-Yep, it's here. Almost a year after [the previous release](http://localhost:4000/2015/05/29/faker-15-is-released.html), Faker 1.6 has been released, with a ton and a half of new fake data, ridiculously useful new formatters, new locales, and bug fixes. Of course, it's totally backwards compatible with the previous version. Ready to dive in?
+Yep, it's here. Almost a year after [the previous release](http://redotheweb.com/2015/05/29/faker-15-is-released.html), Faker 1.6 has been released, with a ton and a half of new fake data, ridiculously useful new formatters, new locales, and bug fixes. Of course, it's totally backwards compatible with the previous version. Ready to dive in?
 
 ## New Formatters
 


### PR DESCRIPTION
I were reading your post [Faker 1.6 is Released](http://www.redotheweb.com/2016/04/29/faker-1-6.html) and noticed that there was a link that was pointing to the localhost instead of the correct site.

Therefore this patch :)
